### PR TITLE
Fix sign-in handler token response and stabilize logger mock

### DIFF
--- a/backend/src/http/handlers/sign-in.post.ts
+++ b/backend/src/http/handlers/sign-in.post.ts
@@ -58,10 +58,9 @@ export const signInPost: IHandler = async ({ req, ctx }) => {
 
   return {
     data: {
-      accessToken,
+      token: accessToken,
       refreshToken,
-      userData: { ...userExists, password_hash: undefined },
     },
-    status: 201,
+    status: 200,
   };
 };

--- a/backend/tests/jwt/jwt.test.ts
+++ b/backend/tests/jwt/jwt.test.ts
@@ -5,6 +5,9 @@ mock.module("../../src/logger/logger", () => {
   return {
     logger: {
       error: mock(() => {}),
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      debug: mock(() => {}),
     },
   };
 });


### PR DESCRIPTION
## Summary
- Ensure `signInPost` returns token, refresh token, and status 200
- Expand logger mock to include debug/info/warn methods so other tests run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895c9ace4dc8323a59d37c986f8a7cd